### PR TITLE
Yeni API Adresi

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_BACKEND_ENDPOINT=http://dev.falcons.iafl.net/api/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # use the official Bun image
 # see all versions at https://hub.docker.com/r/oven/bun/tags
-# original backend (ef)endpoint = https://falcons-erp-api-dev.sd.iafl.net/
+# original backend (ef)endpoint = https://dev.falcons.iafl.net/
 FROM oven/bun:1-debian AS bun
 
 WORKDIR /usr/src/app
 
-ENV VITE_BACKEND_ENDPOINT=https://falcons-erp-api-dev.sd.iafl.net/
+ENV VITE_BACKEND_ENDPOINT=https://dev.falcons.iafl.net/
 
 COPY . .
 RUN bun install

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ERP-UI
 Falcons ERP Web App UI
 
-- Automatically deployed on : https://falcons-erp-api-dev.sd.iafl.net/ | [Alternative](https://octopus-app-2cww7.ondigitalocean.app/swagger-ui/index.html)
-- Swagger UI: https://falcons-erp-api-dev.sd.iafl.net/swagger-ui/index.html  | [Alternative](https://octopus-app-2cww7.ondigitalocean.app/swagger-ui/index.html)
+- Automatically deployed on : https://dev.falcons.iafl.net/swagger-ui/index.html)
+- Swagger UI: https://dev.falcons.iafl.net/swagger-ui/index.html 
 
 
 to run locally, first clone and execute below codes at root directory 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,11 +13,11 @@ export default defineConfig({
 
   //todo: this is a temp fix for cors
   //http://localhost:8080/api
-  //https://falcons-erp-api-dev.sd.iafl.net/api/
+  //https://dev.falcons.iafl.net/api/
   server: {
     proxy: {
       '/api': {
-        target: 'https://falcons-erp-api-dev.sd.iafl.net/api/',
+        target: 'https://dev.falcons.iafl.net/api/',
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/api/, '')


### PR DESCRIPTION
## Degisiklikler
- Eski API'yi gosteren ayarlar degisti
- `.env.development` dosyasi eklendi,  niye dersen buraya bak https://vite.dev/guide/env-and-mode

## Sonuc 
- CORS hatasi almiyoruz 
- console.log'dan gelen mesaj ( `BACKEND_ENDPOINT must be set. Please copy .env.dist to .env`)  artik yok.